### PR TITLE
Extend filter for role of user

### DIFF
--- a/app/views/redmine_required_field/_settings.html.erb
+++ b/app/views/redmine_required_field/_settings.html.erb
@@ -5,42 +5,19 @@
   rrf_all_projects = RedmineRequiredField.related_project_options
   rrf_all_roles = RedmineRequiredField.related_roles
   rrf_issue_required = RedmineRequiredField.settings_issue_required
-  rrf_settings_label = [[l('redmine_required_field.settings.exclude_roles'), 0],[l('redmine_required_field.settings.check_assignee_only'),1]]
-  
   current_roles = RedmineRequiredField.current_roles
 %>
 
 <%= hidden_field_tag 'settings[issue_required]', rrf_issue_required %>
-<%= rrf_all_roles%>
 
 <div class='tabular settings'>
-  <fieldset class="box">
-    <legend>
-      <b>
-        Ihre derzeitig zugewiesenen Rollen
-      </b>
-    </legend>
-    <table id="current_roles">
-      <tbody>
-    <%current_roles.each do |elem|%>
-      <tr>
-        <td><%=elem[0]%></td>
-        <td>(<%=elem[1]%>)</td>
-      </tr>
-    <%end%>
-    </tbody>
-    </table>
-  </fieldset>
-
   <fieldset class="box">
     <legend>
       <b>
         <%= l('redmine_required_field.settings.issues_matching_will_require_time_entry') %>
       </b>
     </legend>
-
     <br>
-
     <table id='rrf_issue_required' class='list'>
       <thead>
         <tr>
@@ -92,21 +69,17 @@
       <br>
       <%= check_box_tag 'role_excluded' %>
       <%= label_tag 'role_excluded', l('redmine_required_field.settings.exclude_roles'),class:'inline' %>
-        
       
       <p>
         <%= submit_tag l(:button_add), :name => :responsive_update, :id => :responsive_update %>
         (**)
       </p>
 
-
       <br>
       <span>(*) = <%= l('redmine_required_field.closed_status') %></span>
       <br>
       <span>(**) = <%= l('redmine_required_field.need_to_click_apply_to_save_settings') %></span>
       <br>
-
-     
 
   </fieldset>
 </div>
@@ -119,12 +92,9 @@
   var rrf_trackers = <%= raw rrf_all_trackers.map(&:reverse).to_h.to_json %>;
   var rrf_projects = <%= raw rrf_all_projects.map(&:reverse).to_h.to_json %>;
   var rrf_roles = <%= raw rrf_all_roles.map(&:reverse).to_h.to_json %>;
-  
-  
 
   function rrf_redraw_issue_required() {
     var table_body = '';
-
     $.each(rrf_current_issue_required, function(ix, data) {
       console.log(data);
       table_body += '<tr>' +
@@ -152,8 +122,7 @@
 
     var setting_role_excluded = $('#role_excluded').is(':checked') ? "1":"0";
     var setting_check_assignee_only = $('#check_assignee_only').is(':checked') ? "1":"0";
-    console.log(setting_role_excluded);
-    console.log(setting_check_assignee_only);
+    
     rrf_current_issue_required.push({
       project_ids: (setting_project_ids || []),
       tracker_ids: (setting_tracker_ids || []),
@@ -162,7 +131,7 @@
       role_excluded: (setting_role_excluded),
       check_assignee_only: (setting_check_assignee_only)
     });
-    console.log(rrf_current_issue_required);
+    
     rrf_redraw_issue_required();
 
     return false;

--- a/app/views/redmine_required_field/_settings.html.erb
+++ b/app/views/redmine_required_field/_settings.html.erb
@@ -3,12 +3,34 @@
   rrf_all_trackers = RedmineRequiredField.related_tracker_options
   rrf_all_issue_statuses = RedmineRequiredField.related_issue_status_options
   rrf_all_projects = RedmineRequiredField.related_project_options
+  rrf_all_roles = RedmineRequiredField.related_roles
   rrf_issue_required = RedmineRequiredField.settings_issue_required
+  rrf_settings_label = [[l('redmine_required_field.settings.exclude_roles'), 0],[l('redmine_required_field.settings.check_assignee_only'),1]]
+  
+  current_roles = RedmineRequiredField.current_roles
 %>
 
 <%= hidden_field_tag 'settings[issue_required]', rrf_issue_required %>
+<%= rrf_all_roles%>
 
 <div class='tabular settings'>
+  <fieldset class="box">
+    <legend>
+      <b>
+        Ihre derzeitig zugewiesenen Rollen
+      </b>
+    </legend>
+    <table id="current_roles">
+      <tbody>
+    <%current_roles.each do |elem|%>
+      <tr>
+        <td><%=elem[0]%></td>
+        <td>(<%=elem[1]%>)</td>
+      </tr>
+    <%end%>
+    </tbody>
+    </table>
+  </fieldset>
 
   <fieldset class="box">
     <legend>
@@ -22,9 +44,11 @@
     <table id='rrf_issue_required' class='list'>
       <thead>
         <tr>
-          <th><%= t(:label_project_plural) %></th>
-          <th><%= t(:label_tracker_plural) %></th>
-          <th><%= t(:label_issue_status_plural) %></th>
+          <th><%= content_tag :label, t(:label_project_plural) %></th>
+          <th><%= content_tag :label, t(:label_tracker_plural) %></th>
+          <th><%= content_tag :label, t(:label_issue_status_plural) %></th>
+          <th><%= content_tag :label, t(:label_role_plural) %></th>
+          <th><%= content_tag :label, t(:label_settings) %></th>
           <th></th>
         </tr>
       </thead>
@@ -43,22 +67,33 @@
     </legend>
 
     <div id='rrf_issue_required_form' class='tabular settings'>
-
-      <p>
+      <div style="display:flex; width:100%;" >
+      <p style="padding: 10px; display:flex;flex-direction: column;">
         <%= content_tag :label, t(:label_project_plural) %>
         <%= select_tag 'rrf_responsive_setting[project_ids]', options_for_select(rrf_all_projects), :multiple => true, :size => 30 %>
       </p>
 
-      <p>
+      <p style="padding: 10px; display:flex;flex-direction: column;">
         <%= content_tag :label, t(:label_tracker_plural) %>
         <%= select_tag 'rrf_responsive_setting[tracker_ids]', options_for_select(rrf_all_trackers), :multiple => true, :size => 30 %>
       </p>
 
-      <p>
+      <p style="padding: 10px; display:flex;flex-direction: column;">
         <%= content_tag :label, t(:label_issue_status_plural) %>
         <%= select_tag 'rrf_responsive_setting[issue_status_ids]', options_for_select(rrf_all_issue_statuses), :multiple => true, :size => 30 %>
       </p>
-
+      <p style="padding: 10px; display:flex;flex-direction: column;">
+        <%= content_tag :label, t(:label_role_plural) %>
+        <%= select_tag 'rrf_responsive_setting[role_ids]', options_for_select(rrf_all_roles), :multiple => true, :size => 30 %>
+      </p>
+      </div>
+      <%= check_box_tag 'check_assignee_only' %>
+      <%= label_tag 'check_assignee_only', l('redmine_required_field.settings.check_assignee_only'),class:'inline' %>
+      <br>
+      <%= check_box_tag 'role_excluded' %>
+      <%= label_tag 'role_excluded', l('redmine_required_field.settings.exclude_roles'),class:'inline' %>
+        
+      
       <p>
         <%= submit_tag l(:button_add), :name => :responsive_update, :id => :responsive_update %>
         (**)
@@ -71,7 +106,7 @@
       <span>(**) = <%= l('redmine_required_field.need_to_click_apply_to_save_settings') %></span>
       <br>
 
-     </div>
+     
 
   </fieldset>
 </div>
@@ -83,15 +118,22 @@
   var rrf_issue_statuses = <%= raw rrf_all_issue_statuses.map(&:reverse).to_h.to_json %>;
   var rrf_trackers = <%= raw rrf_all_trackers.map(&:reverse).to_h.to_json %>;
   var rrf_projects = <%= raw rrf_all_projects.map(&:reverse).to_h.to_json %>;
+  var rrf_roles = <%= raw rrf_all_roles.map(&:reverse).to_h.to_json %>;
+  
+  
 
   function rrf_redraw_issue_required() {
     var table_body = '';
 
     $.each(rrf_current_issue_required, function(ix, data) {
+      console.log(data);
       table_body += '<tr>' +
         '<td>' + $.map(data.project_ids, function(k, ix) {return rrf_projects[k]}).join('<br>') + '</td>' +
         '<td>' + $.map(data.tracker_ids, function(k, ix) {return rrf_trackers[k]}).join('<br>') + '</td>' +
         '<td>' + $.map(data.issue_status_ids, function(k, ix) {return rrf_issue_statuses[k]}).join('<br>') + '</td>' +
+        '<td>' + $.map(data.role_ids, function(k, ix) {return rrf_roles[k]}).join('<br>') + '</td>' +
+        '<td>' + (data.role_excluded=="1" ? '<%=l('redmine_required_field.settings.exclude_roles')%>':'') + '<br>' +
+        (data.check_assignee_only=="1" ? '<%=l('redmine_required_field.settings.check_assignee_only')%>':'') +'<br>' + '</td>' +
         '<td><a class="icon icon-del rrf_issue_required_delete" data-issue_required_index_id="' + ix + '">&nbsp;</a></td>' +
         '</tr>';
     });
@@ -106,13 +148,21 @@
     var setting_project_ids = $('#rrf_responsive_setting_project_ids').val();
     var setting_tracker_ids = $('#rrf_responsive_setting_tracker_ids').val();
     var setting_issue_status_ids = $('#rrf_responsive_setting_issue_status_ids').val();
+    var setting_role_ids = $('#rrf_responsive_setting_role_ids').val();
 
+    var setting_role_excluded = $('#role_excluded').is(':checked') ? "1":"0";
+    var setting_check_assignee_only = $('#check_assignee_only').is(':checked') ? "1":"0";
+    console.log(setting_role_excluded);
+    console.log(setting_check_assignee_only);
     rrf_current_issue_required.push({
       project_ids: (setting_project_ids || []),
       tracker_ids: (setting_tracker_ids || []),
-      issue_status_ids: (setting_issue_status_ids || [])
+      issue_status_ids: (setting_issue_status_ids || []),
+      role_ids: (setting_role_ids || []),
+      role_excluded: (setting_role_excluded),
+      check_assignee_only: (setting_check_assignee_only)
     });
-
+    console.log(rrf_current_issue_required);
     rrf_redraw_issue_required();
 
     return false;

--- a/app/views/redmine_required_field/_settings.html.erb
+++ b/app/views/redmine_required_field/_settings.html.erb
@@ -5,7 +5,6 @@
   rrf_all_projects = RedmineRequiredField.related_project_options
   rrf_all_roles = RedmineRequiredField.related_roles
   rrf_issue_required = RedmineRequiredField.settings_issue_required
-  current_roles = RedmineRequiredField.current_roles
 %>
 
 <%= hidden_field_tag 'settings[issue_required]', rrf_issue_required %>
@@ -45,24 +44,24 @@
 
     <div id='rrf_issue_required_form' class='tabular settings'>
       <div style="display:flex; width:100%;" >
-      <p style="padding: 10px; display:flex;flex-direction: column;">
-        <%= content_tag :label, t(:label_project_plural) %>
-        <%= select_tag 'rrf_responsive_setting[project_ids]', options_for_select(rrf_all_projects), :multiple => true, :size => 30 %>
-      </p>
+        <p style="padding: 10px; display:flex;flex-direction: column;">
+          <%= content_tag :label, t(:label_project_plural) %>
+          <%= select_tag 'rrf_responsive_setting[project_ids]', options_for_select(rrf_all_projects), :multiple => true, :size => 30 %>
+        </p>
 
-      <p style="padding: 10px; display:flex;flex-direction: column;">
-        <%= content_tag :label, t(:label_tracker_plural) %>
-        <%= select_tag 'rrf_responsive_setting[tracker_ids]', options_for_select(rrf_all_trackers), :multiple => true, :size => 30 %>
-      </p>
+        <p style="padding: 10px; display:flex;flex-direction: column;">
+          <%= content_tag :label, t(:label_tracker_plural) %>
+          <%= select_tag 'rrf_responsive_setting[tracker_ids]', options_for_select(rrf_all_trackers), :multiple => true, :size => 30 %>
+        </p>
 
-      <p style="padding: 10px; display:flex;flex-direction: column;">
-        <%= content_tag :label, t(:label_issue_status_plural) %>
-        <%= select_tag 'rrf_responsive_setting[issue_status_ids]', options_for_select(rrf_all_issue_statuses), :multiple => true, :size => 30 %>
-      </p>
-      <p style="padding: 10px; display:flex;flex-direction: column;">
-        <%= content_tag :label, t(:label_role_plural) %>
-        <%= select_tag 'rrf_responsive_setting[role_ids]', options_for_select(rrf_all_roles), :multiple => true, :size => 30 %>
-      </p>
+        <p style="padding: 10px; display:flex;flex-direction: column;">
+          <%= content_tag :label, t(:label_issue_status_plural) %>
+          <%= select_tag 'rrf_responsive_setting[issue_status_ids]', options_for_select(rrf_all_issue_statuses), :multiple => true, :size => 30 %>
+        </p>
+        <p style="padding: 10px; display:flex;flex-direction: column;">
+          <%= content_tag :label, t(:label_role_plural) %>
+          <%= select_tag 'rrf_responsive_setting[role_ids]', options_for_select(rrf_all_roles), :multiple => true, :size => 30 %>
+        </p>
       </div>
       <%= check_box_tag 'check_assignee_only' %>
       <%= label_tag 'check_assignee_only', l('redmine_required_field.settings.check_assignee_only'),class:'inline' %>
@@ -96,14 +95,13 @@
   function rrf_redraw_issue_required() {
     var table_body = '';
     $.each(rrf_current_issue_required, function(ix, data) {
-      console.log(data);
       table_body += '<tr>' +
         '<td>' + $.map(data.project_ids, function(k, ix) {return rrf_projects[k]}).join('<br>') + '</td>' +
         '<td>' + $.map(data.tracker_ids, function(k, ix) {return rrf_trackers[k]}).join('<br>') + '</td>' +
         '<td>' + $.map(data.issue_status_ids, function(k, ix) {return rrf_issue_statuses[k]}).join('<br>') + '</td>' +
         '<td>' + $.map(data.role_ids, function(k, ix) {return rrf_roles[k]}).join('<br>') + '</td>' +
-        '<td>' + (data.role_excluded=="1" ? '<%=l('redmine_required_field.settings.exclude_roles')%>':'') + '<br>' +
-        (data.check_assignee_only=="1" ? '<%=l('redmine_required_field.settings.check_assignee_only')%>':'') +'<br>' + '</td>' +
+        '<td>' + (data.role_excluded=="1" ? '<%= l('redmine_required_field.settings.exclude_roles') %>':'') + '<br>' +
+        (data.check_assignee_only=="1" ? '<%= l('redmine_required_field.settings.check_assignee_only') %>':'') +'<br>' + '</td>' +
         '<td><a class="icon icon-del rrf_issue_required_delete" data-issue_required_index_id="' + ix + '">&nbsp;</a></td>' +
         '</tr>';
     });
@@ -120,8 +118,8 @@
     var setting_issue_status_ids = $('#rrf_responsive_setting_issue_status_ids').val();
     var setting_role_ids = $('#rrf_responsive_setting_role_ids').val();
 
-    var setting_role_excluded = $('#role_excluded').is(':checked') ? "1":"0";
-    var setting_check_assignee_only = $('#check_assignee_only').is(':checked') ? "1":"0";
+    var setting_role_excluded = $('#role_excluded').is(':checked') ? "1" : "0";
+    var setting_check_assignee_only = $('#check_assignee_only').is(':checked') ? "1" : "0";
     
     rrf_current_issue_required.push({
       project_ids: (setting_project_ids || []),

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,13 @@
+
+de:
+  redmine_required_field:
+    closed_status: Closed status
+    need_to_click_apply_to_save_settings: Anwenden klicken, um die Änderungen anzuwenden
+    settings:
+      add_issue_matchers: Auswahlkriterium hinzufügen
+      issues_matching_will_require_time_entry: Zutreffende Tickets müssen bei Änderungen mit einer Zeitaufwandsangabe versehen werden
+      exclude_roles: Angegebene Rollen von der Verpflichtung zur Angabe der Zeit ausschließen
+      check_assignee_only: Nur anwenden wenn Bearbeitung durch Person die "Zugewiesen an:" gleicht
+    spent_time_is_required_for_this_issue: Angabe zum Zeitaufwand wird benötigt
+
+

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -7,7 +7,7 @@ de:
       add_issue_matchers: Auswahlkriterium hinzufügen
       issues_matching_will_require_time_entry: Zutreffende Tickets müssen bei Änderungen mit einer Zeitaufwandsangabe versehen werden
       exclude_roles: Angegebene Rollen von der Verpflichtung zur Angabe der Zeit ausschließen
-      check_assignee_only: Nur anwenden wenn Bearbeitung durch Person die "Zugewiesen an:" gleicht
+      check_assignee_only: Nur anwenden wenn Bearbeiter der zugewiesenen Person gleicht
     spent_time_is_required_for_this_issue: Angabe zum Zeitaufwand wird benötigt
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,8 @@ en:
     settings:
       add_issue_matchers: Add issue matchers
       issues_matching_will_require_time_entry: Matching issues will require time entries
+      exclude_roles: Exclude roles from being obligated to fill required field
+      check_assignee_only: Only match for assignee
     spent_time_is_required_for_this_issue: Spent time is required for this issue
 
 

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -6,8 +6,8 @@ tr:
     settings:
       add_issue_matchers: İş eşleştiricileri ekleyiniz
       issues_matching_will_require_time_entry: Eşleşen iş kayıtlarında  zaman kaydı girilmesi zorunlu olacak
-      exclude_roles: Rolleri zorunlu alanı doldurma zorunluluğundan hariç tutu
-      check_assignee_only: Only match for assignee
+      exclude_roles: Rolleri zorunlu alanı doldurma zorunluluğundan hariç tut
+      check_assignee_only: Sadece atanan ile eşleştir
     spent_time_is_required_for_this_issue: Bu iş için harcanan zaman girilmesi zorunludur
 
 

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -6,5 +6,8 @@ tr:
     settings:
       add_issue_matchers: İş eşleştiricileri ekleyiniz
       issues_matching_will_require_time_entry: Eşleşen iş kayıtlarında  zaman kaydı girilmesi zorunlu olacak
+      exclude_roles: Rolleri zorunlu alanı doldurma zorunluluğundan hariç tutu
+      check_assignee_only: Only match for assignee
     spent_time_is_required_for_this_issue: Bu iş için harcanan zaman girilmesi zorunludur
+
 

--- a/lib/redmine_required_field.rb
+++ b/lib/redmine_required_field.rb
@@ -13,7 +13,10 @@ module RedmineRequiredField
   PROJECT_IDS = 'project_ids'.freeze
   TRACKER_IDS = 'tracker_ids'.freeze
   ISSUE_STATUS_IDS = 'issue_status_ids'.freeze
-
+  ROLE_IDS = 'role_ids'.freeze
+  SETTINGS = 'rrf_settings'.freeze
+  ROLE_EXCLUDED = 'role_excluded'.freeze
+  CHECK_ASSIGNEE_ONLY = 'check_assignee_only'.freeze
 
   def self.settings
     HashWithIndifferentAccess.new(Setting[:plugin_redmine_required_field])
@@ -59,6 +62,10 @@ module RedmineRequiredField
     Tracker.sorted.pluck(:name, :id)
   end
 
+  def self.related_roles
+    Role.sorted.pluck(:name, :id)
+  end
+
   def self.setting_values_match_id(rrf_setting, value)
     return true if rrf_setting.blank?
     # not for ids, but may need to enable for other attribute types
@@ -66,5 +73,19 @@ module RedmineRequiredField
 
     rrf_setting.map(&:to_i).include?(value.to_i)
   end
+  def self.current_roles
+    User.current.roles.sorted.pluck(:name,:id)
+  end
+  def self.setting_values_contain_ids(rrf_setting, arr)
+    return true if rrf_setting.blank?
+    # not for ids, but may need to enable for other attribute types
+    # return true if value.blank?
+    idary = Array.new
+    arr.each do |elem|
+      idary.push(elem[1])
+    end
+    (rrf_setting.map(&:to_i) & idary).any?
+  end
+
 end
 

--- a/lib/redmine_required_field.rb
+++ b/lib/redmine_required_field.rb
@@ -80,10 +80,7 @@ module RedmineRequiredField
     return true if rrf_setting.blank?
     # not for ids, but may need to enable for other attribute types
     # return true if value.blank?
-    idary = Array.new
-    arr.each do |elem|
-      idary.push(elem[1])
-    end
+    idary = arr.map{|k| k[1]}
     (rrf_setting.map(&:to_i) & idary).any?
   end
 

--- a/lib/redmine_required_field/patches/issues_controller_patch.rb
+++ b/lib/redmine_required_field/patches/issues_controller_patch.rb
@@ -36,6 +36,30 @@ module RedmineRequiredField
 
 
       def rrf_params_match_settings(rrf_setting)
+        #check role and assignee behavior(negate match for given roles if checkbox is set, and only apply filter if attached to only is set and user matches attached to )
+        user_is_assigned_to = User.current.id==@issue.assigned_to_id
+        if rrf_setting[RedmineRequiredField::ROLE_EXCLUDED] == '1'
+
+          if rrf_setting[RedmineRequiredField::CHECK_ASSIGNEE_ONLY] =='1'
+            if !user_is_assigned_to
+              return false
+            else
+              setting_role_ids = rrf_setting[RedmineRequiredField::ROLE_IDS]
+              matched = !RedmineRequiredField.setting_values_contain_ids(setting_role_ids, RedmineRequiredField.current_roles)
+            return false unless matched
+            end
+          end
+        else
+          if rrf_setting[RedmineRequiredField::CHECK_ASSIGNEE_ONLY]='1'
+            if !user_is_assigned_to
+              return false
+            else
+              setting_role_ids = rrf_setting[RedmineRequiredField::ROLE_IDS]
+              matched = RedmineRequiredField.setting_values_contain_ids(setting_role_ids, RedmineRequiredField.current_roles)
+            return false unless matched
+            end
+          end
+        end
         setting_project_ids = rrf_setting[RedmineRequiredField::PROJECT_IDS]
         matched = RedmineRequiredField.setting_values_match_id(setting_project_ids, @issue.project_id)
         return false unless matched
@@ -46,7 +70,7 @@ module RedmineRequiredField
 
         setting_issue_status_ids = rrf_setting[RedmineRequiredField::ISSUE_STATUS_IDS]
         matched = RedmineRequiredField.setting_values_match_id(setting_issue_status_ids, params[:issue][:status_id])
-
+        
         matched
       end
 

--- a/lib/redmine_required_field/patches/issues_controller_patch.rb
+++ b/lib/redmine_required_field/patches/issues_controller_patch.rb
@@ -37,29 +37,16 @@ module RedmineRequiredField
 
       def rrf_params_match_settings(rrf_setting)
         #check role and assignee behavior(negate match for given roles if checkbox is set, and only apply filter if attached to only is set and user matches attached to )
-        user_is_assigned_to = User.current.id==@issue.assigned_to_id
-        if rrf_setting[RedmineRequiredField::ROLE_EXCLUDED] == '1'
-
-          if rrf_setting[RedmineRequiredField::CHECK_ASSIGNEE_ONLY] =='1'
-            if !user_is_assigned_to
-              return false
-            else
-              setting_role_ids = rrf_setting[RedmineRequiredField::ROLE_IDS]
-              matched = !RedmineRequiredField.setting_values_contain_ids(setting_role_ids, RedmineRequiredField.current_roles)
-            return false unless matched
-            end
-          end
-        else
-          if rrf_setting[RedmineRequiredField::CHECK_ASSIGNEE_ONLY]='1'
-            if !user_is_assigned_to
-              return false
-            else
-              setting_role_ids = rrf_setting[RedmineRequiredField::ROLE_IDS]
-              matched = RedmineRequiredField.setting_values_contain_ids(setting_role_ids, RedmineRequiredField.current_roles)
-            return false unless matched
-            end
-          end
+        if rrf_setting[RedmineRequiredField::CHECK_ASSIGNEE_ONLY] == '1'
+          return false if User.current.id != @issue.assigned_to_id
         end
+        setting_role_ids = rrf_setting[RedmineRequiredField::ROLE_IDS]
+        matched = RedmineRequiredField.setting_values_contain_ids(setting_role_ids, RedmineRequiredField.current_roles)
+        if rrf_setting[RedmineRequiredField::ROLE_EXCLUDED] == '1'
+          matched = !matched
+        end
+        return false unless matched
+
         setting_project_ids = rrf_setting[RedmineRequiredField::PROJECT_IDS]
         matched = RedmineRequiredField.setting_values_match_id(setting_project_ids, @issue.project_id)
         return false unless matched
@@ -70,7 +57,7 @@ module RedmineRequiredField
 
         setting_issue_status_ids = rrf_setting[RedmineRequiredField::ISSUE_STATUS_IDS]
         matched = RedmineRequiredField.setting_values_match_id(setting_issue_status_ids, params[:issue][:status_id])
-        
+
         matched
       end
 


### PR DESCRIPTION
(be careful, i am not an experienced programmer)
I added role based filtering to your plugin, and the option to apply the filter only to users that are equal to the assigned user.
The role selection can be reversed, so the roles added to the filter will be excluded (important because multiple roles are possible for a single user -> neccessary to target just a single role, eg management won't have to fill required fields)
